### PR TITLE
Change API_URL to merrymake

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.GIT_HOST = exports.SSH_HOST = exports.HTTP_HOST = exports.API_URL = void 0;
-exports.API_URL = `api.mist-cloud.io`;
+exports.API_URL = `api.merrymake.io`;
 exports.HTTP_HOST = `https://${exports.API_URL}`;
 exports.SSH_HOST = `${exports.API_URL}`;
 exports.GIT_HOST = `ssh://mist@${exports.API_URL}`;


### PR DESCRIPTION
To solve the following error:

```
gitpod /workspace/mono/merrymakeconfig (main) $ mm clone
ERROR mist@api.mist-cloud.io: Permission denied (publickey).

gitpod /workspace/mono/merrymakeconfig (main) $ ssh mist@api.merrymake.io "whoami"
["johan@abildskov.io"]
```